### PR TITLE
[PR for Issue #45] Add 'timestamp' to Message

### DIFF
--- a/src/wintermute-core/message.cc
+++ b/src/wintermute-core/message.cc
@@ -24,8 +24,13 @@ using Wintermute::Message;
 using Wintermute::Module;
 using Wintermute::MessagePrivate;
 using Wintermute::Util::Serializable;
+using std::chrono::high_resolution_clock;
 
-MessagePrivate::MessagePrivate() : data(Message::HashType())
+MessagePrivate::MessagePrivate() :
+  data(Message::HashType()),
+  sender(),
+  receiver(),
+  timestamp(time(nullptr))
 {
 }
 
@@ -34,11 +39,13 @@ void MessagePrivate::clone(const SharedPtr<MessagePrivate>& d)
   this->data = d->data;
   this->sender = d->sender;
   this->receiver = d->receiver;
+  this->timestamp = d->timestamp;
 }
 
 bool MessagePrivate::isEmpty() const
 {
   /// TODO This needs a better check. If anything, check only if the sender AND
   //payload are empty/null.
-  return !sender.isNull() && !receiver.isNull() && !data.empty();
+  return !sender.isNull() && !receiver.isNull() &&
+         !data.empty() && timestamp != 0;
 }

--- a/src/wintermute-core/message.cc
+++ b/src/wintermute-core/message.cc
@@ -24,13 +24,13 @@ using Wintermute::Message;
 using Wintermute::Module;
 using Wintermute::MessagePrivate;
 using Wintermute::Util::Serializable;
-using std::chrono::high_resolution_clock;
+using std::chrono::system_clock;
 
 MessagePrivate::MessagePrivate() :
   data(Message::HashType()),
   sender(),
   receiver(),
-  timestamp(time(nullptr))
+  timestamp(system_clock::now())
 {
 }
 
@@ -47,5 +47,5 @@ bool MessagePrivate::isEmpty() const
   /// TODO This needs a better check. If anything, check only if the sender AND
   //payload are empty/null.
   return !sender.isNull() && !receiver.isNull() &&
-         !data.empty() && timestamp != 0;
+         !data.empty() && timestamp != system_clock::time_point();
 }

--- a/src/wintermute-core/message.hh
+++ b/src/wintermute-core/message.hh
@@ -31,7 +31,7 @@ public:
   Message::HashType data;
   Module::Designation sender;
   Module::Designation receiver;
-  std::time_t timestamp;
+  std::chrono::system_clock::time_point timestamp;
 
   void clone(const SharedPtr<MessagePrivate>& d);
   bool isEmpty() const;

--- a/src/wintermute-core/message.hh
+++ b/src/wintermute-core/message.hh
@@ -18,6 +18,7 @@
 #include <map>
 #include <string>
 #include <memory>
+#include <chrono>
 #include "message.hpp"
 #include "module.hpp"
 
@@ -30,6 +31,7 @@ public:
   Message::HashType data;
   Module::Designation sender;
   Module::Designation receiver;
+  std::time_t timestamp;
 
   void clone(const SharedPtr<MessagePrivate>& d);
   bool isEmpty() const;

--- a/src/wintermute-core/message.hpp
+++ b/src/wintermute-core/message.hpp
@@ -71,6 +71,8 @@ public:
 
   Module::Designation receiver() const;
 
+  string timestamp() const;
+
   void setSender(const Module::Designation& newSender);
 
   void setReceiver(const Module::Designation& newReceiver);

--- a/test/bootstrap
+++ b/test/bootstrap
@@ -6,9 +6,8 @@
 
 make_vagrant_build_dir()
 {
-  cd ~vagrant;
-  rm build -rf;
-  mkdir -p build;
+  rm /vagrant/build -rf;
+  mkdir -p /vagrant/build;
 }
 
 ansible_path() {
@@ -62,12 +61,13 @@ dump_log() {
   if [ "$TRAVIS" == true ]; then
     cat "$(find "$TRAVIS_BUILD_DIR" -type f -name "*Last*.log")";
   else
-    cat "$(find ~vagrant/build -type f -name "*Last*.log")";
+    cat "$(find /vagrant -type f -name "*Last*.log")";
   fi
 }
 
 run_build() {
   export CTEST_PARALLEL_LEVEL=2;
+  echo $PWD;
   preset_library_path;
   make -j2 all;
   make -e test;
@@ -88,8 +88,7 @@ generate_build() {
     _compiler=$(which clang-3.5);
   fi
 
-  CC=gcc CXX=${_compiler} cmake \
-    -DCI_BUILD=ON "$1" || exit 32
+  CC=gcc CXX=${_compiler} cmake -DCI_BUILD=ON "$1" || exit 32
 }
 
 
@@ -102,18 +101,19 @@ case "$1" in
     ;;
   "--generate-vagrant" )
     make_vagrant_build_dir
-    generate_build /vagrant
+    generate_build "/vagrant"
     ;;
   "--run" )
     run_build
     ;;
   "--run-vagrant" )
-    PWD=/home/vagrant/build run_build;
+    PWD=/vagrant/build run_build;
     ;;
   "--dump-log" )
     dump_log
     ;;
   "--vagrant" )
+    preset_library_path;
     /vagrant/test/bootstrap --generate-vagrant
     /vagrant/test/bootstrap --run-vagrant
     ;;
@@ -121,7 +121,7 @@ case "$1" in
     if [ "$TRAVIS" == true ]; then
       cat "$(find "$TRAVIS_BUILD_DIR" -type f -name "*LastBuild*.log")";
     else
-      cat "$(find ~vagrant/build -type f -name "*LastBuild*.log")";
+      cat "$(find /vagrant -type f -name "*LastBuild*.log")";
     fi
     ;;
   "--post" )

--- a/test/unit/message.hh
+++ b/test/unit/message.hh
@@ -25,6 +25,15 @@ using Wintermute::Module;
 class MessageTestSuite : public CxxTest::TestSuite
 {
 public:
+  string getCurrentTimeString() const
+  {
+    const time_t curTime = time(nullptr);
+    string strTime = asctime(std::gmtime(&curTime));
+    strTime.pop_back();
+    strTime += " UTC";
+    return strTime;
+  }
+
   void testClone(void)
   {
     Message::HashType data;
@@ -45,15 +54,34 @@ public:
 
   void testSchemaCheck(void)
   {
+    const auto timestamp = std::chrono::system_clock::now();
+    const auto ctimestamp = std::chrono::system_clock::to_time_t(timestamp);
+    const string timestampString = ctime(&ctimestamp);
     Module::Designation sender("input", "in.wintermute.test");
     Module::Designation receiver("output", "in.wintermute.test");
     Message::HashType data;
     data.insert(std::make_pair("foo", std::to_string(100)));
 
-    Message message(data, receiver, sender);
+    Serializable::Map messageMap;
+    messageMap.insert(make_pair("sender", sender));
+    messageMap.insert(make_pair("receiver", receiver));
+    messageMap.insert(make_pair("payload", Serializable::toString(data)));
+    messageMap.insert(make_pair("timestamp", timestampString));
+
+    Message message;
+    message = messageMap;
 
     TS_ASSERT_EQUALS ( message.sender() , sender );
     TS_ASSERT_EQUALS ( message.receiver() , receiver );
     TS_ASSERT_EQUALS ( message.payload() , data );
+    TS_ASSERT_EQUALS ( message.timestamp(), timestampString );
+  }
+
+  void testEnsureThatTimestampIsUtc()
+  {
+    Message message = craftRandomMessage();
+    const string obtainedTimestring = message.timestamp();
+
+    TS_ASSERT ( obtainedTimestring.find("UTC") != 0 );
   }
 };

--- a/test/unit/message.hh
+++ b/test/unit/message.hh
@@ -16,11 +16,15 @@
  */
 
 #include "test_suite.hpp"
+#include <chrono>
+#include <wintermute-core/util/serializable.hpp>
 #include <wintermute-core/message.hpp>
 #include <cxxtest/TestSuite.h>
 
+using Wintermute::Util::Serializable;
 using Wintermute::Message;
 using Wintermute::Module;
+using std::make_pair;
 
 class MessageTestSuite : public CxxTest::TestSuite
 {
@@ -54,9 +58,7 @@ public:
 
   void testSchemaCheck(void)
   {
-    const auto timestamp = std::chrono::system_clock::now();
-    const auto ctimestamp = std::chrono::system_clock::to_time_t(timestamp);
-    const string timestampString = ctime(&ctimestamp);
+    const string timestampString = getCurrentTimeString();
     Module::Designation sender("input", "in.wintermute.test");
     Module::Designation receiver("output", "in.wintermute.test");
     Message::HashType data;

--- a/test/unit/message.hh
+++ b/test/unit/message.hh
@@ -85,5 +85,7 @@ public:
     const string obtainedTimestring = message.timestamp();
 
     TS_ASSERT ( obtainedTimestring.find("UTC") != 0 );
+    TS_ASSERT_EQUALS ( obtainedTimestring.find("UTC"),
+        obtainedTimestring.length() - 3 );
   }
 };


### PR DESCRIPTION
Providing timestamps with messages allows receivers to do chrono-specific work and
can help with queuing which message should be handled.

---

Blocks #45.
